### PR TITLE
ensure moving_avg_scores shape matches neuron_weights shape

### DIFF
--- a/prompting/validators/forward.py
+++ b/prompting/validators/forward.py
@@ -87,7 +87,7 @@ async def run_step(
     event = {"name": name}
     start_time = time.time()
     # Get the list of uids to query for this step.
-    uids = get_random_uids(self, k=10, exclude=exclude).to(self.device)
+    uids = get_random_uids(self, k=k, exclude=exclude).to(self.device)
     axons = [self.metagraph.axons[uid] for uid in uids]
     synapse = prompting.protocol.Prompting(roles=["user"], messages=[prompt])
 

--- a/prompting/validators/utils.py
+++ b/prompting/validators/utils.py
@@ -263,9 +263,16 @@ def load_state(self):
     bt.logging.info("load_state()")
     try:
         state_dict = torch.load(f"{self.config.neuron.full_path}/model.torch")
-        # Check for nans in saved state dict
         neuron_weights = torch.tensor(state_dict["neuron_weights"])
-        if not torch.isnan(neuron_weights).any():
+        # Check to ensure that the size of the neruon weights matches the metagraph size.
+        if neuron_weights.shape != (self.metagraph.n,):
+            bt.logging.warning(
+                f"Neuron weights shape {neuron_weights.shape} does not match metagraph n {self.metagraph.n}"
+                "Populating new moving_averaged_scores IDs with zeros"
+            )
+            self.moving_averaged_scores[:len(neuron_weights)] = neuron_weights.to(self.device)
+        # Check for nans in saved state dict
+        elif not torch.isnan(neuron_weights).any():
             self.moving_averaged_scores = neuron_weights.to(self.device)
         self.hotkeys = state_dict["neuron_hotkeys"]
         bt.logging.success(

--- a/prompting/validators/utils.py
+++ b/prompting/validators/utils.py
@@ -270,7 +270,9 @@ def load_state(self):
                 f"Neuron weights shape {neuron_weights.shape} does not match metagraph n {self.metagraph.n}"
                 "Populating new moving_averaged_scores IDs with zeros"
             )
-            self.moving_averaged_scores[:len(neuron_weights)] = neuron_weights.to(self.device)
+            self.moving_averaged_scores[: len(neuron_weights)] = neuron_weights.to(
+                self.device
+            )
         # Check for nans in saved state dict
         elif not torch.isnan(neuron_weights).any():
             self.moving_averaged_scores = neuron_weights.to(self.device)


### PR DESCRIPTION
Cleans up a bug when loading from the state dict. If the saved `neuron_weights` from the state dict is smaller than the `metagraph.n` than we'd run into a shape issue.  This is rare but would happen if the metagraph grows in-between saving and loading.

Also replaces `k`, was hardcoded to 10.