### PR TITLE
Mock reward dedup

### DIFF
--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -190,7 +190,6 @@ class neuron:
                 MockRewardModel(RewardModelType.nsfw.value),
             ]
             bt.logging.debug(str(self.reward_functions))
-            self.blacklist = MockRewardModel(RewardModelType.blacklist.value)
         else:
             self.reward_weights = torch.tensor(
                 [

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -52,7 +52,6 @@ from prompting.validators.reward import (
     OpenAssistantRewardModel,
     ReciprocateRewardModel,
     RelevanceRewardModel,
-    MockRewardModel,
     DahoasRewardModel,
     DiversityRewardModel,
     PromptRewardModel,

--- a/prompting/validators/mock.py
+++ b/prompting/validators/mock.py
@@ -45,7 +45,23 @@ class MockGatingModel(BaseGatingModel):
         pass
 
 
-class MockRewardModel(torch.nn.Module):
+class MockRewardModel(BaseRewardModel):
+    @property
+    def name(self) -> str:
+        return self.mock_name
+
+    def __init__(self, mock_name: str = "MockReward"):
+        super().__init__()
+        self.mock_name = mock_name
+        self.question_blacklist = {}
+
+    def apply(self, prompt: str, completion: List[str], name: str) -> torch.FloatTensor:
+        mock_reward = torch.tensor([1 for _ in completion], dtype=torch.float32)
+        return mock_reward, mock_reward
+
+    def reset(self):
+        return self
+
     def reward(
         self,
         completions_with_prompt: List[str],

--- a/prompting/validators/mock.py
+++ b/prompting/validators/mock.py
@@ -21,13 +21,14 @@ import asyncio
 import bittensor as bt
 from prompting.validators.prompts import FirewallPrompt, FollowupPrompt, AnswerPrompt
 from prompting.validators.gating import BaseGatingModel
+from prompting.validators.reward import BaseRewardModel
 from typing import List
 
 
 class MockGatingModel(BaseGatingModel):
     def __init__(self, num_uids: int):
         super(MockGatingModel, self).__init__()
-        # super(MockGatingModel, self).__init__()
+
         self.num_uids = num_uids
         self.linear = torch.nn.Linear(256, 10)
 
@@ -53,7 +54,8 @@ class MockRewardModel(BaseRewardModel):
     def __init__(self, mock_name: str = "MockReward"):
         super().__init__()
         self.mock_name = mock_name
-        self.question_blacklist = {}
+        self.question_blacklist = []
+        self.answer_blacklist = []
 
     def apply(self, prompt: str, completion: List[str], name: str) -> torch.FloatTensor:
         mock_reward = torch.tensor([1 for _ in completion], dtype=torch.float32)

--- a/prompting/validators/reward/__init__.py
+++ b/prompting/validators/reward/__init__.py
@@ -6,7 +6,6 @@ from .open_assistant import OpenAssistantRewardModel
 from .reciprocate import ReciprocateRewardModel
 from .relevance import RelevanceRewardModel
 from .reward import BaseRewardModel
-from .reward import MockRewardModel
 from .dahoas import DahoasRewardModel
 from .diversity import DiversityRewardModel
 from .prompt import PromptRewardModel

--- a/prompting/validators/reward/reward.py
+++ b/prompting/validators/reward/reward.py
@@ -138,19 +138,3 @@ class BaseRewardModel:
         # Return the filled rewards.
         return filled_rewards, filled_rewards_normalized
 
-
-class MockRewardModel(BaseRewardModel):
-    @property
-    def name(self) -> str:
-        return self.mock_name
-
-    def __init__(self, mock_name: str = "MockReward"):
-        super().__init__()
-        self.mock_name = mock_name
-
-    def apply(self, prompt: str, completion: List[str], name: str) -> torch.FloatTensor:
-        mock_reward = torch.tensor([1 for _ in completion], dtype=torch.float32)
-        return mock_reward, mock_reward
-
-    def reset(self):
-        return self

--- a/prompting/validators/reward/reward.py
+++ b/prompting/validators/reward/reward.py
@@ -137,4 +137,3 @@ class BaseRewardModel:
 
         # Return the filled rewards.
         return filled_rewards, filled_rewards_normalized
-

--- a/prompting/validators/utils.py
+++ b/prompting/validators/utils.py
@@ -23,7 +23,7 @@ import copy
 import bittensor as bt
 import prompting.validators as validators
 from prompting.validators.misc import ttl_get_block
-from prompting.validators.reward import MockRewardModel
+from prompting.validators.mock import MockRewardModel
 
 
 def should_reinit_wandb(self):

--- a/prompting/validators/utils.py
+++ b/prompting/validators/utils.py
@@ -23,7 +23,6 @@ import copy
 import bittensor as bt
 import prompting.validators as validators
 from prompting.validators.misc import ttl_get_block
-from prompting.validators.mock import MockRewardModel
 
 
 def should_reinit_wandb(self):
@@ -49,7 +48,7 @@ def init_wandb(self, reinit=False):
     if self.config.neuron.use_custom_gating_model:
         tags.append("custom_gating_model")
     for fn in self.reward_functions:
-        if not isinstance(fn, MockRewardModel):
+        if not self.config.neuron.mock_reward_models:
             tags.append(str(fn.name))
     if self.config.neuron.disable_set_weights:
         tags.append("disable_set_weights")


### PR DESCRIPTION
Addresses duplication of `MockRewardModel`, was crashing validator when running with `--neuron.mock_reward_models`.

* Removes `reward.MockRewardModel` in favor of `mock.MockRewardModel`
* Consistent use of `reward.MockRewardModel` -> `mock.MockRewardModel`