### PR TITLE
Lower diversity boundary to 0.2

### DIFF
--- a/prompting/validators/reward/diversity.py
+++ b/prompting/validators/reward/diversity.py
@@ -68,7 +68,7 @@ class DiversityRewardModel(BaseRewardModel):
         self.history_reward_bottom_k = 2
         self.historic_embeddings = torch.tensor([]).to(self.device)
         self.history_range = (500, 15500)
-        self.boundary = 0.5
+        self.boundary = 0.2
 
     def get_embeddings(self, sentences: List[str]) -> "torch.FloatTensor":
         """Runs a forward pass through the model.


### PR DESCRIPTION
After some analysis and team discussions, we believe that reducing the diversity model's threshold to 0.2 could enhance the overall network quality, considering the current conjuncture of the text-prompting subnet

- lowers diversity threshold from .5 to .2
