### PR TITLE
ensure mock reward model has new blacklist functions or crashes

### DIFF
--- a/prompting/validators/mock.py
+++ b/prompting/validators/mock.py
@@ -60,6 +60,12 @@ class MockRewardModel(BaseRewardModel):
         self.question_blacklist = []
         self.answer_blacklist = []
 
+    def add(self, texts: List[str]):
+        pass
+
+    def set_counter_to_half(self):
+        pass
+
     def apply(self, prompt: str, completion: List[str], name: str) -> torch.FloatTensor:
         mock_reward = torch.tensor([1 for _ in completion], dtype=torch.float32)
         return mock_reward, {}


### PR DESCRIPTION
This is just so that when running a mock validator with `--neuron.mock_reward_models` the validator doesn't die.