### PR TITLE
Remove axon port as a duplicate argument

### DIFF
--- a/prompting/baseminer/config.py
+++ b/prompting/baseminer/config.py
@@ -68,9 +68,6 @@ def get_config() -> "bt.Config":
     # Using command-line arguments allows users to customize various miner settings.
     parser = argparse.ArgumentParser()
 
-    parser.add_argument(
-        "--axon.port", type=int, default=8098, help="Port to run the axon on."
-    )
     # Subtensor network to connect to
     parser.add_argument(
         "--subtensor.network",


### PR DESCRIPTION
The removed line tries to add the `axon.port` argument a second time, where it is already added in `bt.axon.add_args`  
This causes an exception to be raised in `bt.axon.add_args` which prevents any other axon arguments from being added.  
Removing the line fixes this.  

See also #83 which depends on this change