### PR TITLE
Pass the axon external IP

### DIFF
--- a/prompting/baseminer/miner.py
+++ b/prompting/baseminer/miner.py
@@ -108,7 +108,12 @@ class Miner(ABC):
             bt.logging.info(f"Running miner on uid: {self.my_subnet_uid}")
 
         # The axon handles request processing, allowing validators to send this process requests.
-        self.axon = axon or bt.axon(wallet=self.wallet, port=self.config.axon.port)
+        self.axon = axon or \
+            bt.axon(
+                wallet=self.wallet,
+                port=self.config.axon.port, 
+                external_ip=self.config.axon.external_ip
+            )
         # Attach determiners which functions are called when servicing a request.
         bt.logging.info(f"Attaching forward function to axon.")
         self.axon.attach(

--- a/prompting/baseminer/miner.py
+++ b/prompting/baseminer/miner.py
@@ -108,12 +108,11 @@ class Miner(ABC):
             bt.logging.info(f"Running miner on uid: {self.my_subnet_uid}")
 
         # The axon handles request processing, allowing validators to send this process requests.
-        self.axon = axon or \
-            bt.axon(
-                wallet=self.wallet,
-                port=self.config.axon.port, 
-                external_ip=self.config.axon.external_ip
-            )
+        self.axon = axon or bt.axon(
+            wallet=self.wallet,
+            port=self.config.axon.port,
+            external_ip=self.config.axon.external_ip,
+        )
         # Attach determiners which functions are called when servicing a request.
         bt.logging.info(f"Attaching forward function to axon.")
         self.axon.attach(


### PR DESCRIPTION
Depends on #82 

This change allows a miner to pass an external IP for the axon to the chain.
This is useful for services like RunPod where the external IP check may not function correctly.