### PR TITLE
blacklist flag from 1 -> 0

### DIFF
--- a/prompting/validators/reward/blacklist.py
+++ b/prompting/validators/reward/blacklist.py
@@ -302,7 +302,7 @@ class Blacklist(BaseRewardModel):
                 and fuzz.partial_ratio(ngram, completion.lower())
                 > self.partial_ratio_boundary
             ):
-                reward_event.reward = 1
+                reward_event.reward = 0
                 reward_event.matched_ngram = ngram
                 reward_event.significance_score = score
                 return reward_event


### PR DESCRIPTION
Activate ngram blacklist that will punish repeated key-takeaways/ summary responses that does not make sense in responding questions in prompt.