### PR TITLE
Increment max penalty + complement task with layout criteria

### DIFF
--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -194,7 +194,7 @@ class neuron:
                 MockRewardModel(RewardModelType.nsfw.value),
             ]
             self.penalty_functions = [
-                TaskValidationPenaltyModel(max_penalty=0.6),
+                TaskValidationPenaltyModel(max_penalty=0.75),
                 ContentMatchPenaltyModel(max_penalty=0.2),
                 KeywordMatchPenaltyModel(max_penalty=1),
             ]

--- a/prompting/validators/criteria.py
+++ b/prompting/validators/criteria.py
@@ -241,4 +241,4 @@ class MatchLayoutCriteria(TaskCriterion):
         return penalties
 
     def compose_text(self) -> str:
-        return self.text.format(layout_type=self.layout_type)
+        return self.text.format(layout_type=self.layout_type.value)

--- a/prompting/validators/reward/reward.py
+++ b/prompting/validators/reward/reward.py
@@ -178,7 +178,7 @@ class BaseRewardModel:
             bt.logging.warning(
                 f"The tensor from {self.name} contains NaN values: {filled_rewards_normalized}"
             )
-            filled_rewards_normalized.nan_to_num_(nan=0.0)
+            filled_rewards_normalized = filled_rewards_normalized.nan_to_num_(nan=0.0)
 
         # Return the filled rewards.
         return filled_rewards_normalized, reward_events

--- a/prompting/validators/tasks.py
+++ b/prompting/validators/tasks.py
@@ -29,7 +29,7 @@ from prompting.validators.criteria import (
     SimpleResponseLayoutCriteria,
     MatchContentCriteria,
     MatchLayoutCriteria,
-    LayoutMatchTypeEnum
+    LayoutMatchTypeEnum,
 )
 
 
@@ -126,12 +126,12 @@ class QuestionAnswerTask(Task):
 def create_summarization_task(base_text: str) -> SummaryTask:
     # scope 1: bullet points, scope 2: numbered list, scope 3: simple layout
     scope = random.randint(1, 3)
-    
+
     select_bullet_point_layout = scope == 1
     select_numbered_list_layout = scope == 2
 
     # scope 1 or 2: define criteria set for bullet points or numbered list
-    if select_bullet_point_layout or select_numbered_list_layout:                
+    if select_bullet_point_layout or select_numbered_list_layout:
         if select_bullet_point_layout:
             layout_criteria = MatchLayoutCriteria(
                 layout_type=LayoutMatchTypeEnum.UNORDERED_LIST,
@@ -141,7 +141,7 @@ def create_summarization_task(base_text: str) -> SummaryTask:
         else:
             layout_criteria = MatchLayoutCriteria(
                 layout_type=LayoutMatchTypeEnum.NUMBERED_LIST,
-                penalty=0.5,                
+                penalty=0.5,
             )
 
         possible_other_criterion = [
@@ -155,7 +155,7 @@ def create_summarization_task(base_text: str) -> SummaryTask:
                 target_length=random.randint(8, 12),
                 unit=TextLengthUnitEnum.SENTENCES,
             ),
-        ]    
+        ]
     # scope 3: define criteria set for simple layout
     else:
         layout_criteria = SimpleResponseLayoutCriteria(penalty=0.5)
@@ -182,7 +182,7 @@ def create_summarization_task(base_text: str) -> SummaryTask:
         task_type="summarization",
         task_name="augment",
     )
-  
+
 
 def create_qg_task(base_text: str, index: int) -> QuestionGenerationTask:
     questions_prefixes = [

--- a/prompting/validators/tasks.py
+++ b/prompting/validators/tasks.py
@@ -260,16 +260,16 @@ def create_qa_task(base_text: str, index: int) -> QuestionAnswerTask:
     answer_should_not_include_criteria = MatchContentCriteria(
         words_array=["?"],
         n_words=1,
-        penalty=0.2,
+        penalty=0.25,
         contentMatchType=ContentMatchTypeEnum.INCLUDES,
         negate_match=True,
         text="Your response should not include any question marks",
     )
 
-    simple_response_layout_criteria = SimpleResponseLayoutCriteria(penalty=0.2)
+    simple_response_layout_criteria = SimpleResponseLayoutCriteria(penalty=0.25)
 
     words_criteria = MatchLengthCriteria(
-        penalty=0.2,
+        penalty=0.25,
         target_length=random.randint(50, 200),
         unit=TextLengthUnitEnum.WORDS,
     )

--- a/prompting/validators/tasks.py
+++ b/prompting/validators/tasks.py
@@ -28,6 +28,8 @@ from prompting.validators.criteria import (
     ContentMatchTypeEnum,
     SimpleResponseLayoutCriteria,
     MatchContentCriteria,
+    MatchLayoutCriteria,
+    LayoutMatchTypeEnum
 )
 
 
@@ -122,28 +124,65 @@ class QuestionAnswerTask(Task):
 
 
 def create_summarization_task(base_text: str) -> SummaryTask:
-    possible_criterias = [
-        MatchLengthCriteria(
-            penalty=0.1,
-            target_length=random.randint(50, 200),
-            unit=TextLengthUnitEnum.WORDS,
-        ),
-        MatchLengthCriteria(
-            penalty=0.1,
-            target_length=random.randint(4, 8),
-            unit=TextLengthUnitEnum.SENTENCES,
-        ),
-    ]
+    # scope 1: bullet points, scope 2: numbered list, scope 3: simple layout
+    scope = random.randint(1, 3)
+    
+    select_bullet_point_layout = scope == 1
+    select_numbered_list_layout = scope == 2
 
-    sampled_criterias = random.sample(possible_criterias, 1)
+    # scope 1 or 2: define criteria set for bullet points or numbered list
+    if select_bullet_point_layout or select_numbered_list_layout:                
+        if select_bullet_point_layout:
+            layout_criteria = MatchLayoutCriteria(
+                layout_type=LayoutMatchTypeEnum.UNORDERED_LIST,
+                penalty=0.5,
+                text="Your response should be ordered in format of bullet points.",
+            )
+        else:
+            layout_criteria = MatchLayoutCriteria(
+                layout_type=LayoutMatchTypeEnum.NUMBERED_LIST,
+                penalty=0.5,                
+            )
+
+        possible_other_criterion = [
+            MatchLengthCriteria(
+                penalty=0.25,
+                target_length=random.randint(100, 200),
+                unit=TextLengthUnitEnum.WORDS,
+            ),
+            MatchLengthCriteria(
+                penalty=0.25,
+                target_length=random.randint(8, 12),
+                unit=TextLengthUnitEnum.SENTENCES,
+            ),
+        ]    
+    # scope 3: define criteria set for simple layout
+    else:
+        layout_criteria = SimpleResponseLayoutCriteria(penalty=0.5)
+
+        possible_other_criterion = [
+            MatchLengthCriteria(
+                penalty=0.25,
+                target_length=random.randint(50, 200),
+                unit=TextLengthUnitEnum.WORDS,
+            ),
+            MatchLengthCriteria(
+                penalty=0.25,
+                target_length=random.randint(4, 8),
+                unit=TextLengthUnitEnum.SENTENCES,
+            ),
+        ]
+
+    random_sampled_criterion = random.sample(possible_other_criterion, 1)
+    defined_criteria = [layout_criteria] + random_sampled_criterion
 
     return SummaryTask(
         base_text=base_text,
-        criteria=sampled_criterias,
+        criteria=defined_criteria,
         task_type="summarization",
         task_name="augment",
     )
-
+  
 
 def create_qg_task(base_text: str, index: int) -> QuestionGenerationTask:
     questions_prefixes = [
@@ -192,12 +231,12 @@ def create_qg_task(base_text: str, index: int) -> QuestionGenerationTask:
 
     other_random_criteria = [
         MatchLengthCriteria(
-            penalty=0.1,
+            penalty=0.25,
             target_length=random.randint(10, 40),
             unit=TextLengthUnitEnum.WORDS,
         ),
         MatchLengthCriteria(
-            penalty=0.1,
+            penalty=0.25,
             target_length=random.randint(40, 150),
             unit=TextLengthUnitEnum.CHARACTERS,
         ),


### PR DESCRIPTION
- increment max penalty to .75
- complements summary task creation with layout criteria (bullet points, numbered list and “raw” simple layout)
- increase penalty landscape for all tasks to sum to .75

**Note:** The tasks of **qg** and **qa** already follow a defined layout, so the expansion was performed on the summarization task